### PR TITLE
Fix typo in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./../../gradlew :thridparty:hnsw-jni:build --info
+./../../gradlew :thirdparty:hnsw-jni:build --info


### PR DESCRIPTION
Project root was thridparty instead of thirdparty